### PR TITLE
Docker: Add mongosh, make base-image explicit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,9 @@
-FROM node:16.13.0
+FROM docker.io/node:16.13.0
 WORKDIR /app
+
+# Install MongoDB Client
+RUN cd /tmp; wget https://downloads.mongodb.com/compass/mongodb-mongosh_1.1.8_$(dpkg --print-architecture).deb && dpkg -i mongodb-mongosh_1.1.8_$(dpkg --print-architecture).deb && rm mongodb-mongosh_1.1.8_$(dpkg --print-architecture).deb
+
 COPY ["package.json", "package-lock.json*", "./"]
 RUN npm install
 COPY . .


### PR DESCRIPTION
Adding mongosh to the Docker image allows debugging the running
container. The current base image was not explicitly pulled from
docker-hub, this is done explicitly now.